### PR TITLE
statusline: always show the 7d exhaust/reset estimate

### DIFF
--- a/user/.claude/statusline.sh
+++ b/user/.claude/statusline.sh
@@ -151,8 +151,9 @@ mag_color() {
   case $? in 2) printf '%s' "$RED";; 1) printf '%s' "$ORANGE";; *) printf '%s' "$GREEN";; esac
 }
 
-# eta_for: seconds until a window hits 100% at its pace so far, printed only
-# if it would exhaust *before* it resets; empty otherwise.
+# eta_for: seconds until a window hits 100% at its pace so far. Capped at 4× the
+# window length -- past that a 1%-used window extrapolates to months out, which
+# is noise rather than a forecast (and would overflow burn_color's awk %d).
 eta_for() {
   local used=$1 resets=$2 dur=$3
   [ -z "$used" ] && return
@@ -160,12 +161,35 @@ eta_for() {
   awk -v u="$used" 'BEGIN{exit !(u>0)}' || return   # need real usage to extrapolate
   local rem=$(( resets - now ))
   [ "$rem" -le 0 ] && return
-  local elapsed=$(( dur - rem ))
-  [ "$elapsed" -lt 300 ] && return                  # too early in window to trust
+  # need a real sample before extrapolating: 2% of the window, floored at 5min.
+  # a flat floor would let 15min into a 7d window forecast "exhausts tomorrow".
+  local elapsed=$(( dur - rem )) min=$(( dur / 50 ))
+  [ "$min" -lt 300 ] && min=300
+  [ "$elapsed" -lt "$min" ] && return
   local t
-  t=$(awk -v u="$used" -v e="$elapsed" 'BEGIN{printf "%d", (100-u)*e/u}')
-  [ "$t" -ge "$rem" ] && return                     # window resets before you run out
+  t=$(awk -v u="$used" -v e="$elapsed" -v c="$(( dur * 4 ))" \
+        'BEGIN{t=(100-u)*e/u; printf "%d", (t>c)? c : t}')
   printf '%s' "$t"
+}
+
+# window_times: "exhaust/reset" for a rate-limit window, e.g. "3:20pm/Tue 9am".
+# The exhaust half is colored by how much of the window it leaves on the table --
+# red runs dry early, green outlasts the reset -- so an exhaust date *past* the
+# reset is the "you're pacing fine" signal rather than a hidden segment. Degrades
+# to the reset alone when too little of the window has elapsed to infer a pace.
+window_times() {
+  local used=$1 resets=$2 dur=$3 eta rem
+  [ -z "$resets" ] && return
+  rem=$(( resets - now ))
+  [ "$rem" -le 0 ] && return
+  eta=$(eta_for "$used" "$resets" "$dur")
+  if [ -n "$eta" ]; then
+    printf '%s%s%s/%s' \
+      "$(burn_color "$eta" "$rem")" "$(fmt_when "$(( now + eta ))")" "$RESET" \
+      "$(fmt_when "$resets")"
+  else
+    fmt_when "$resets"
+  fi
 }
 
 # read-only git only: never take the optional index.lock, so a render can't
@@ -263,16 +287,12 @@ weekly_retail=$(weekly_retail_cached)
 spend=""
 [ -n "$weekly_retail" ] && spend="$(mag_color "$weekly_retail" 1000 3000)$(fmt_money "$weekly_retail")${RESET}"
 
-# --- 🔥 weekly cluster: retail spend · 7d% · 7d exhaust/reset (times only when burning) ---
+# --- 🔥 weekly cluster: retail spend · 7d% · 7d exhaust/reset ---
 burn=""
 [ -n "$spend" ] && burn="$spend"
 [ -n "$seven_day" ] && burn="${burn:+$burn }$(pct "$seven_day")"
-eta7=$(eta_for "$seven_day" "$seven_day_resets" 604800)
-if [ -n "$eta7" ]; then
-  reset7=$(( seven_day_resets - now ))
-  times="$(burn_color "$eta7" "$reset7")$(fmt_when "$(( now + eta7 ))")${RESET}/$(fmt_when "$seven_day_resets")"
-  burn="${burn:+$burn }$times"
-fi
+times7=$(window_times "$seven_day" "$seven_day_resets" 604800)
+[ -n "$times7" ] && burn="${burn:+$burn }$times7"
 [ -n "$burn" ] && line2+=("🔥 $burn")
 
 # --- ⏱️ 5-hour window only ---

--- a/user/.claude/statusline.sh
+++ b/user/.claude/statusline.sh
@@ -7,8 +7,8 @@ cwd=$(j '.workspace.current_dir // .cwd')
 branch=$(j '.worktree.branch')
 model=$(j '.model.display_name')
 effort=$(j 'if (.effort|type)=="object" then .effort.level elif (.effort|type)=="string" then .effort else empty end')
-[ -z "$effort" ] && effort=$(jq -r '.effortLevel // empty' "$HOME/.claude/settings.local.json" 2>/dev/null)
-[ -z "$effort" ] && effort=$(jq -r '.effortLevel // empty' "$HOME/.claude/settings.json" 2>/dev/null)
+[ -z "$effort" ] && effort=$(jq -r '.effortLevel // empty' "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.local.json" 2>/dev/null)
+[ -z "$effort" ] && effort=$(jq -r '.effortLevel // empty' "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json" 2>/dev/null)
 used=$(j '.context_window.used_percentage')
 five_hour=$(j '.rate_limits.five_hour.used_percentage')
 five_hour_resets=$(j '.rate_limits.five_hour.resets_at')
@@ -68,7 +68,7 @@ fmt_money() {
 # (rolling), computed by ccusage. Reads a ≤60s cache instantly and refreshes in
 # the background so the status line never waits on log parsing.
 weekly_retail_cached() {
-  local dir="$HOME/.claude/.cache" file lock age val
+  local dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.cache" file lock age val
   file="$dir/weekly_retail"; lock="$dir/weekly_retail.lock"
   mkdir -p "$dir" 2>/dev/null
   [ -f "$file" ] && val=$(cat "$file" 2>/dev/null)
@@ -95,7 +95,7 @@ weekly_retail_cached() {
 # daily24_retail_cached: echo retail-$ spend over the last 24h, from ccusage
 # billing blocks (background-cached). Sums blocks whose start is within 24h.
 daily24_retail_cached() {
-  local dir="$HOME/.claude/.cache" file lock age val
+  local dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.cache" file lock age val
   file="$dir/daily24_retail"; lock="$dir/daily24_retail.lock"
   mkdir -p "$dir" 2>/dev/null
   [ -f "$file" ] && val=$(cat "$file" 2>/dev/null)


### PR DESCRIPTION
The `🔥` segment's usage estimate was invisible exactly when it was useful.

`eta_for()` ended with `[ "$t" -ge "$rem" ] && return` — if the projected exhaust landed *after* the window reset, it returned empty. The reset time was rendered inside that same `if [ -n "$eta7" ]` block, so both numbers disappeared together. Net effect: you could only see when your window resets while you were already burning too hot, and never saw that you were comfortably on pace.

## Before / after

Same real payload (7d at 63%, 5h at 23%), captured from a live session:

```
BEFORE  💡 Opus 5 (1M) xhigh · 🔥 $2.7k 63% · ⏱️ 3h: 23%
AFTER   💡 Opus 5 (1M) xhigh · 🔥 $2.7k 63% Wed 12:13pm/Tue 7:07pm · ⏱️ 3h: 23%
```

Reads as `exhaust/reset`. Here the 7d window projects to run dry Wed 12:13pm but resets Tue 7:07pm — exhaust lands after reset, so it renders green: pacing fine, will not hit the wall. That is the state that previously rendered as nothing at all.

## Changes

The display decision moves out of `eta_for()` into a new `window_times()`, which always renders `exhaust/reset`. `burn_color()` already mapped `eta > rem` to green, so "how late" colors correctly with no new logic.

Making the estimate always-visible surfaced two latent bugs that the old gate had been masking:

- **Unbounded projection.** A 0.1%-used window extrapolated months out and overflowed `burn_color()`'s `awk %d`. Now capped at 4× the window length.
- **Too-eager extrapolation.** The flat `elapsed < 300` sample floor was tuned for the 5h window. At 13 minutes into a 7d window with 1% used, it forecast "exhausts in 22h" and painted it **red** — a false alarm off an 800s sample. Now requires 2% of the window elapsed (floored at 5min); below that the segment shows the reset time alone.

The 5h window stays percent-only — an estimate at that cadence is noise.

First commit is a separate pre-existing fix: the effort-level fallback and both ccusage cache dirs hardcoded `$HOME/.claude`, breaking under a custom `CLAUDE_CONFIG_DIR`.

## Verification

`bash -n` clean. Rendered against a live captured payload (confirming the harness does send `rate_limits.{five_hour,seven_day}.{used_percentage,resets_at}`), plus a synthetic matrix covering: pacing-fine, burning-hot, fresh window below the sample guard, zero usage, reset timestamp in the past, missing `rate_limits` entirely, and 0.1%-used cap overflow. No browser evidence — this is terminal output, so same-payload renders are the equivalent artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AArF2auKeeGnaVU3RDjmwR